### PR TITLE
Feat/add docker security scanner

### DIFF
--- a/.gitlab-ci-templates/trivy.yml
+++ b/.gitlab-ci-templates/trivy.yml
@@ -18,7 +18,7 @@
   allow_failure: true
   script:
     # Build image
-    - docker build -t $IMAGE_PROJECT_NAME:test ./dashboard
+    - docker build -t $IMAGE_PROJECT_NAME:test ./$PROJECT_PATH
     # Build report
     - ./trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@contrib/gitlab.tpl" -o gl-container-scanning-report.json $IMAGE_PROJECT_NAME:test
     # Print report

--- a/.gitlab-ci-templates/trivy.yml
+++ b/.gitlab-ci-templates/trivy.yml
@@ -9,7 +9,6 @@
     DOCKER_HOST: tcp://docker:2375/
     DOCKER_DRIVER: overlay2
     DOCKER_TLS_CERTDIR: ""
-    IMAGE_PROJECT_NAME: "terminus7/sci-toolkit-dashboard"
   before_script:
     - apk add --no-cache curl
     - export VERSION=$(curl --silent "https://api.github.com/repos/aquasecurity/trivy/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
@@ -32,6 +31,4 @@
   artifacts:
     reports:
       container_scanning: gl-container-scanning-report.json
-  only:
-    changes:
-      - dashboard/**/*
+  

--- a/.gitlab-ci-templates/trivy.yml
+++ b/.gitlab-ci-templates/trivy.yml
@@ -1,0 +1,37 @@
+.trivy-template:
+  stage: test
+  image: docker:stable
+  services:
+    - name: docker:dind
+      entrypoint: ["env", "-u", "DOCKER_HOST"]
+      command: ["dockerd-entrypoint.sh"]
+  variables:
+    DOCKER_HOST: tcp://docker:2375/
+    DOCKER_DRIVER: overlay2
+    DOCKER_TLS_CERTDIR: ""
+    IMAGE_PROJECT_NAME: "terminus7/sci-toolkit-dashboard"
+  before_script:
+    - apk add --no-cache curl
+    - export VERSION=$(curl --silent "https://api.github.com/repos/aquasecurity/trivy/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
+    - echo $VERSION
+    - wget https://github.com/aquasecurity/trivy/releases/download/v${VERSION}/trivy_${VERSION}_Linux-64bit.tar.gz
+    - tar zxvf trivy_${VERSION}_Linux-64bit.tar.gz
+  allow_failure: true
+  script:
+    # Build image
+    - docker build -t $IMAGE_PROJECT_NAME:test ./dashboard
+    # Build report
+    - ./trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@contrib/gitlab.tpl" -o gl-container-scanning-report.json $IMAGE_PROJECT_NAME:test
+    # Print report
+    - ./trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --severity HIGH $IMAGE_PROJECT_NAME:test
+    # Fail on high and critical vulnerabilities
+    - ./trivy --exit-code 1 --cache-dir .trivycache/ --severity CRITICAL --no-progress $IMAGE_PROJECT_NAME:test
+  cache:
+    paths:
+      - .trivycache/
+  artifacts:
+    reports:
+      container_scanning: gl-container-scanning-report.json
+  only:
+    changes:
+      - dashboard/**/*

--- a/.gitlab-ci-templates/trivy.yml
+++ b/.gitlab-ci-templates/trivy.yml
@@ -24,7 +24,7 @@
     # Print report
     - ./trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --severity HIGH $IMAGE_PROJECT_NAME:test
     # Fail on high and critical vulnerabilities
-    - ./trivy --exit-code 1 --cache-dir .trivycache/ --severity CRITICAL --no-progress $IMAGE_PROJECT_NAME:test
+    - ./trivy --exit-code 0 --cache-dir .trivycache/ --severity CRITICAL --no-progress $IMAGE_PROJECT_NAME:test
   cache:
     paths:
       - .trivycache/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 stages:
-  - semantic-release
   - test
+  - semantic-release
   - publish
   - build
   - release-operator

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,6 @@
 stages:
   - semantic-release
+  - test
   - publish
   - build
   - release-operator

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,7 @@ stages:
   - semantic-release-helm
 
 include:
+  - local: .gitlab-ci-templates/trivy.yml
   - local: dashboard/.gitlab-ci.yml
   - local: jupyterlab-gpu-image/.gitlab-ci.yml
   - local: runner-image/.gitlab-ci.yml

--- a/dashboard/.gitlab-ci.yml
+++ b/dashboard/.gitlab-ci.yml
@@ -11,43 +11,9 @@ release-dashboard:
     changes:
       - dashboard/**/*
 
-trivy:
-  stage: test
-  image: docker:stable
-  services:
-    - name: docker:dind
-      entrypoint: ["env", "-u", "DOCKER_HOST"]
-      command: ["dockerd-entrypoint.sh"]
-  variables:
-    DOCKER_HOST: tcp://docker:2375/
-    DOCKER_DRIVER: overlay2
-    DOCKER_TLS_CERTDIR: ""
-    IMAGE_PROJECT_NAME: "terminus7/sci-toolkit-dashboard"
-  before_script:
-    - apk add --no-cache curl
-    - export VERSION=$(curl --silent "https://api.github.com/repos/aquasecurity/trivy/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
-    - echo $VERSION
-    - wget https://github.com/aquasecurity/trivy/releases/download/v${VERSION}/trivy_${VERSION}_Linux-64bit.tar.gz
-    - tar zxvf trivy_${VERSION}_Linux-64bit.tar.gz
-  allow_failure: true
-  script:
-    # Build image
-    - docker build -t $IMAGE_PROJECT_NAME:test ./dashboard
-    # Build report
-    - ./trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@contrib/gitlab.tpl" -o gl-container-scanning-report.json $IMAGE_PROJECT_NAME:test
-    # Print report
-    - ./trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --severity HIGH $IMAGE_PROJECT_NAME:test
-    # Fail on high and critical vulnerabilities
-    - ./trivy --exit-code 1 --cache-dir .trivycache/ --severity CRITICAL --no-progress $IMAGE_PROJECT_NAME:test
-  cache:
-    paths:
-      - .trivycache/
-  artifacts:
-    reports:
-      container_scanning: gl-container-scanning-report.json
-  only:
-    changes:
-      - dashboard/**/*
+trivy-dashboard:
+  extends: .trivy-template
+  
 
 publish-dashboard-image:
   stage: publish

--- a/dashboard/.gitlab-ci.yml
+++ b/dashboard/.gitlab-ci.yml
@@ -1,3 +1,14 @@
+trivy-dashboard:
+  extends: .trivy-template
+  variables:
+    IMAGE_PROJECT_NAME: "terminus7/sci-toolkit-dashboard"
+    PROJECT_PATH: "dashboard"
+  only:
+    refs:
+      - master
+    changes:
+      - dashboard/**/*
+
 release-dashboard:
   stage: semantic-release
   image: node:12
@@ -8,15 +19,6 @@ release-dashboard:
   only:
     refs:
       - master
-    changes:
-      - dashboard/**/*
-
-trivy-dashboard:
-  extends: .trivy-template
-  variables:
-    IMAGE_PROJECT_NAME: "terminus7/sci-toolkit-dashboard"
-    PROJECT_PATH: "dashboard"
-  only:
     changes:
       - dashboard/**/*
 

--- a/dashboard/.gitlab-ci.yml
+++ b/dashboard/.gitlab-ci.yml
@@ -13,7 +13,11 @@ release-dashboard:
 
 trivy-dashboard:
   extends: .trivy-template
-  
+  variables:
+    IMAGE_PROJECT_NAME: "terminus7/sci-toolkit-dashboard"
+  only:
+    changes:
+      - dashboard/**/*
 
 publish-dashboard-image:
   stage: publish

--- a/dashboard/.gitlab-ci.yml
+++ b/dashboard/.gitlab-ci.yml
@@ -11,6 +11,44 @@ release-dashboard:
     changes:
       - dashboard/**/*
 
+trivy:
+  stage: test
+  image: docker:stable
+  services:
+    - name: docker:dind
+      entrypoint: ["env", "-u", "DOCKER_HOST"]
+      command: ["dockerd-entrypoint.sh"]
+  variables:
+    DOCKER_HOST: tcp://docker:2375/
+    DOCKER_DRIVER: overlay2
+    DOCKER_TLS_CERTDIR: ""
+    IMAGE_PROJECT_NAME: "terminus7/sci-toolkit-dashboard"
+  before_script:
+    - apk add --no-cache curl
+    - export VERSION=$(curl --silent "https://api.github.com/repos/aquasecurity/trivy/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
+    - echo $VERSION
+    - wget https://github.com/aquasecurity/trivy/releases/download/v${VERSION}/trivy_${VERSION}_Linux-64bit.tar.gz
+    - tar zxvf trivy_${VERSION}_Linux-64bit.tar.gz
+  allow_failure: true
+  script:
+    # Build image
+    - docker build -t $IMAGE_PROJECT_NAME:test ./dashboard
+    # Build report
+    - ./trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@contrib/gitlab.tpl" -o gl-container-scanning-report.json $IMAGE_PROJECT_NAME:test
+    # Print report
+    - ./trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --severity HIGH $IMAGE_PROJECT_NAME:test
+    # Fail on high and critical vulnerabilities
+    - ./trivy --exit-code 1 --cache-dir .trivycache/ --severity CRITICAL --no-progress $IMAGE_PROJECT_NAME:test
+  cache:
+    paths:
+      - .trivycache/
+  artifacts:
+    reports:
+      container_scanning: gl-container-scanning-report.json
+  only:
+    changes:
+      - dashboard/**/*
+
 publish-dashboard-image:
   stage: publish
   image: docker:latest

--- a/dashboard/.gitlab-ci.yml
+++ b/dashboard/.gitlab-ci.yml
@@ -15,6 +15,7 @@ trivy-dashboard:
   extends: .trivy-template
   variables:
     IMAGE_PROJECT_NAME: "terminus7/sci-toolkit-dashboard"
+    PROJECT_PATH: "dashboard"
   only:
     changes:
       - dashboard/**/*

--- a/gitea-oauth2-setup/.gitlab-ci.yml
+++ b/gitea-oauth2-setup/.gitlab-ci.yml
@@ -1,3 +1,14 @@
+trivy-gitea-oauth2-setup:
+  extends: .trivy-template
+  variables:
+    IMAGE_PROJECT_NAME: "terminus7/gitea-oauth2-setup"
+    PROJECT_PATH: "gitea-oauth2-setup"
+  only:
+    refs:
+      - master
+    changes:
+      - gitea-oauth2-setup/**/*
+
 release-gitea-oauth2-setup:
   stage: semantic-release
   image: node:12

--- a/jupyterlab-gpu-image/.gitlab-ci.yml
+++ b/jupyterlab-gpu-image/.gitlab-ci.yml
@@ -1,3 +1,14 @@
+trivy-jupyterlab-gpu-image:
+  extends: .trivy-template
+  variables:
+    IMAGE_PROJECT_NAME: "terminus7/jupyterlab-gpu"
+    PROJECT_PATH: "jupyterlab-gpu-image"
+  only:
+    refs:
+      - master
+    changes:
+      - jupyterlab-gpu-image/**/*
+
 release-jupyterlab-gpu-image:
   stage: semantic-release
   image: node:10

--- a/mlflow/.gitlab-ci.yml
+++ b/mlflow/.gitlab-ci.yml
@@ -15,6 +15,7 @@ trivy-mlflow:
   extends: .trivy-template
   variables:
     IMAGE_PROJECT_NAME: "terminus7/mlflow"
+    PROJECT_PATH: "mlflow"
   only:
     changes:
       - mlflow/**/*

--- a/mlflow/.gitlab-ci.yml
+++ b/mlflow/.gitlab-ci.yml
@@ -11,6 +11,14 @@ release-mlflow-image:
     refs:
       - master
 
+trivy-mlflow:
+  extends: .trivy-template
+  variables:
+    IMAGE_PROJECT_NAME: "terminus7/mlflow"
+  only:
+    changes:
+      - mlflow/**/*
+
 publish_mlflow_docker_image:
   stage: publish
   image: docker:latest

--- a/mlflow/.gitlab-ci.yml
+++ b/mlflow/.gitlab-ci.yml
@@ -1,3 +1,14 @@
+trivy-mlflow:
+  extends: .trivy-template
+  variables:
+    IMAGE_PROJECT_NAME: "terminus7/mlflow"
+    PROJECT_PATH: "mlflow"
+  only:
+    refs:
+      - master
+    changes:
+      - mlflow/**/*
+
 release-mlflow-image:
   stage: semantic-release
   image: node:10
@@ -10,15 +21,6 @@ release-mlflow-image:
       - mlflow/**/*
     refs:
       - master
-
-trivy-mlflow:
-  extends: .trivy-template
-  variables:
-    IMAGE_PROJECT_NAME: "terminus7/mlflow"
-    PROJECT_PATH: "mlflow"
-  only:
-    changes:
-      - mlflow/**/*
 
 publish_mlflow_docker_image:
   stage: publish

--- a/runner-image/.gitlab-ci.yml
+++ b/runner-image/.gitlab-ci.yml
@@ -1,3 +1,14 @@
+trivy-runner-image:
+  extends: .trivy-template
+  variables:
+    IMAGE_PROJECT_NAME: "terminus7/runner-image"
+    PROJECT_PATH: "runner-image"
+  only:
+    refs:
+      - master
+    changes:
+      - runner-image/**/*
+
 release-runner-image:
   stage: semantic-release
   image: node:10

--- a/user-tools-operator/.gitlab-ci.yml
+++ b/user-tools-operator/.gitlab-ci.yml
@@ -1,3 +1,45 @@
+trivy-user-tools-operator:
+  stage: test
+  image: docker:stable
+  services:
+    - name: docker:dind
+      entrypoint: ["env", "-u", "DOCKER_HOST"]
+      command: ["dockerd-entrypoint.sh"]
+  variables:
+    DOCKER_HOST: tcp://docker:2375/
+    DOCKER_DRIVER: overlay2
+    DOCKER_TLS_CERTDIR: ""
+    IMAGE_PROJECT_NAME: "terminus7/sci-toolkit-user-tools-operator" 
+  before_script:
+    - apk add --no-cache curl
+    - export VERSION=$(curl --silent "https://api.github.com/repos/aquasecurity/trivy/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
+    - echo $VERSION
+    - wget https://github.com/aquasecurity/trivy/releases/download/v${VERSION}/trivy_${VERSION}_Linux-64bit.tar.gz
+    - tar zxvf trivy_${VERSION}_Linux-64bit.tar.gz
+    - cd user-tools-operator
+    - ./scripts/install_operator_sdk.sh
+  allow_failure: true
+  script:
+    # Build image
+    - operator-sdk build $IMAGE_PROJECT_NAME:test
+    # Build report
+    - ./trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --format template --template "@contrib/gitlab.tpl" -o gl-container-scanning-report.json $IMAGE_PROJECT_NAME:test
+    # Print report
+    - ./trivy --exit-code 0 --cache-dir .trivycache/ --no-progress --severity HIGH $IMAGE_PROJECT_NAME:test
+    # Fail on high and critical vulnerabilities
+    - ./trivy --exit-code 0 --cache-dir .trivycache/ --severity CRITICAL --no-progress $IMAGE_PROJECT_NAME:test
+  cache:
+    paths:
+      - .trivycache/
+  artifacts:
+    reports:
+      container_scanning: gl-container-scanning-report.json
+  only:
+    refs:
+      - master
+    changes:
+      - user-tools-operator/**/*
+
 release-user-tools-operator:
   stage: semantic-release
   image: node:10

--- a/vscode/.gitlab-ci.yml
+++ b/vscode/.gitlab-ci.yml
@@ -1,3 +1,14 @@
+trivy-vscode:
+  extends: .trivy-template
+  variables:
+    IMAGE_PROJECT_NAME: "terminus7/sci-toolkit-vscode"
+    PROJECT_PATH: "vscode"
+  only:
+    refs:
+      - master
+    changes:
+      - vscode/**/*
+
 release-vscode:
   stage: semantic-release
   image: node:12


### PR DESCRIPTION
In order to have visibility of the security risk of the Docker images that we generate we need to perform a scanner of vulnerabilities.

The tool Trivy is used to achieve this goal, and an artifact with the report is saved in Gitlab to show the report in the Security Dashboard.